### PR TITLE
Recipe card component

### DIFF
--- a/Frontend_Application/src/components/recipe-card-container.component.jsx
+++ b/Frontend_Application/src/components/recipe-card-container.component.jsx
@@ -1,12 +1,48 @@
 import RecipeCard from "./recipe-card.component.jsx";
+import { Stack } from "@mui/material";
 
-const dbMock = [];
+const dbMock = [
+  {
+    recipeId: "1",
+    name: "Pulled Pork",
+    description: "This is a description",
+    imageUrl: "https://www.recipetineats.com/wp-content/uploads/2022/10/12-hour-BBQ-pulled-pork_7-3.jpg?resize=650,813",
+    protein: 150,
+    fat: 100,
+    carbs: 50,
+    calories: 1000,
+  },
+
+  {
+    recipeId: "2",
+    name: "Pulled Pork",
+    description: "This is a description",
+    imageUrl: "https://www.recipetineats.com/wp-content/uploads/2022/10/12-hour-BBQ-pulled-pork_7-3.jpg?resize=650,813",
+    protein: 150,
+    fat: 100,
+    carbs: 50,
+    calories: 1000,
+  },
+
+  {
+    recipeId: "3",
+    name: "Pulled Pork",
+    description: "This is a description",
+    imageUrl: "https://www.recipetineats.com/wp-content/uploads/2022/10/12-hour-BBQ-pulled-pork_7-3.jpg?resize=650,813",
+    protein: 150,
+    fat: 100,
+    carbs: 50,
+    calories: 1000,
+  },
+];
 
 function RecipeCardContainer(props) {
   return (
-    <div>
-      <RecipeCard />
-    </div>
+    <Stack direction="row" spacing={2}>
+      {dbMock.map((recipe) => (
+        <RecipeCard key={recipe.recipeId} recipe={recipe} />
+      ))}
+    </Stack>
   );
 }
 

--- a/Frontend_Application/src/components/recipe-card-container.component.jsx
+++ b/Frontend_Application/src/components/recipe-card-container.component.jsx
@@ -1,0 +1,13 @@
+import RecipeCard from "./recipe-card.component.jsx";
+
+const dbMock = [];
+
+function RecipeCardContainer(props) {
+  return (
+    <div>
+      <RecipeCard />
+    </div>
+  );
+}
+
+export default RecipeCardContainer;

--- a/Frontend_Application/src/components/recipe-card.component.jsx
+++ b/Frontend_Application/src/components/recipe-card.component.jsx
@@ -15,17 +15,18 @@ const PlusIcon = createSvgIcon(
 );
 
 function RecipeCard(props) {
+  const { name, description, imageUrl, protein, fat, carbs, calories } = props.recipe;
   return (
     <Card sx={{ maxWidth: 345 }}>
       <CardActionArea>
-        <CardMedia component="img" height="200" image="https://mui.com/static/images/cards/contemplative-reptile.jpg" alt="" />
+        <CardMedia component="img" height="200" image={imageUrl} alt={name} />
         <CardContent sx={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}>
           <div style={{ width: "80%" }}>
             <Typography gutterBottom variant="h5" component="div">
-              Some Recipe
+              {name}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Carb: 0 | Protein: 0 | Fat: 0
+              Calories: {calories} | Carb: {carbs} | Protein: {protein} | Fat: {fat}
             </Typography>
           </div>
           <Stack direction="row" alignItems="center">

--- a/Frontend_Application/src/components/recipe-card.component.jsx
+++ b/Frontend_Application/src/components/recipe-card.component.jsx
@@ -26,7 +26,7 @@ function RecipeCard(props) {
               {name}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Calories: {calories} | Carb: {carbs} | Protein: {protein} | Fat: {fat}
+              Carb: {carbs} | Protein: {protein} | Fat: {fat}
             </Typography>
           </div>
           <Stack direction="row" alignItems="center">

--- a/Frontend_Application/src/components/recipe-card.component.jsx
+++ b/Frontend_Application/src/components/recipe-card.component.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
+import { Button, CardActionArea, CardActions } from "@mui/material";
+import { createSvgIcon } from "@mui/material/utils";
+
+const PlusIcon = createSvgIcon(
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-6 w-6">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+  </svg>,
+  "Plus"
+);
+
+function RecipeCard(props) {
+  return (
+    <Card sx={{ maxWidth: 345 }}>
+      <CardActionArea>
+        <CardMedia component="img" height="200" image="https://mui.com/static/images/cards/contemplative-reptile.jpg" alt="" />
+        <CardContent sx={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}>
+          <div style={{ width: "80%" }}>
+            <Typography gutterBottom variant="h5" component="div">
+              Some Recipe
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Carb: 0 | Protein: 0 | Fat: 0
+            </Typography>
+          </div>
+          <PlusIcon />
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+export default RecipeCard;

--- a/Frontend_Application/src/components/recipe-card.component.jsx
+++ b/Frontend_Application/src/components/recipe-card.component.jsx
@@ -5,6 +5,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Typography from "@mui/material/Typography";
 import { Button, CardActionArea, CardActions } from "@mui/material";
 import { createSvgIcon } from "@mui/material/utils";
+import Stack from "@mui/material/Stack";
 
 const PlusIcon = createSvgIcon(
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-6 w-6">
@@ -27,7 +28,9 @@ function RecipeCard(props) {
               Carb: 0 | Protein: 0 | Fat: 0
             </Typography>
           </div>
-          <PlusIcon />
+          <Stack direction="row" alignItems="center">
+            <PlusIcon fontSize="large" />
+          </Stack>
         </CardContent>
       </CardActionArea>
     </Card>


### PR DESCRIPTION
### Description of the changes included in this pull request
Made the recipe card to hold basic information to display on the dashboard.
Recipe container holds all of the card and will display on the dashboard.

The Botton for "+" isn't functional just yet. need to add API call to backend once that's set.

### Screenshots
![image](https://github.com/bethanyann/dsd-cohort-2024/assets/115523196/14f73387-33fe-4ab1-9d0c-093f276be848)

### Setup or Testing Instructions
No need for additional install. Using Stack to align few items.

 
