### PR TITLE
Expanded api endpoint documentation

### DIFF
--- a/Backend_Application/src/main/java/dsd/cohort/application/ingredient/IngredientController.java
+++ b/Backend_Application/src/main/java/dsd/cohort/application/ingredient/IngredientController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -21,16 +24,25 @@ public class IngredientController {
         this.ingredientService = ingredientService;
     }
 
-    @Operation(summary = "Get ingredient by id")
+    @Operation(summary = "Get ingredient by id", description = "Get ingredient by id. Ingredient id should be in the format of 'food_bmyxrshbfao9s1amjrvhoauob6mo'")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Ingredient found"),
-        @ApiResponse(responseCode = "500", description = "Ingredient not found")
+        @ApiResponse(responseCode = "200", description = "Ingredient found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = IngredientDTO.class))),
+        @ApiResponse(responseCode = "500", description = "Ingredient not found",
+            content = @Content),
     })
     @GetMapping("/{id}")
     public IngredientEntity getIngredientById(@PathVariable String id) {
         return ingredientService.getIngredientByFoodId(id);
     }
 
+    @Operation(summary = "Get all ingredients", description = "Retrieves all ingredients in the database")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Ingredients found",
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = IngredientDTO.class)))),
+        @ApiResponse(responseCode = "500", description = "Internal server error, could not get ingredients",
+            content = @Content),
+    })
     @GetMapping("/")
     public List<IngredientEntity> getAllIngredients() {
         return ingredientService.getAllIngredients();

--- a/Backend_Application/src/main/java/dsd/cohort/application/recipe/RecipeController.java
+++ b/Backend_Application/src/main/java/dsd/cohort/application/recipe/RecipeController.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -25,18 +28,22 @@ public class RecipeController {
 
     @Operation(summary = "Get all recipes")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "All recipes returned"),
-        @ApiResponse(responseCode = "500", description = "Could not get recipes")
+        @ApiResponse(responseCode = "200", description = "All recipes returned",
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RecipeDTO.class)))),
+        @ApiResponse(responseCode = "500", description = "Could not get recipes",
+            content = @Content()),
     })
     @GetMapping("/")
     public List<RecipeEntity> getAllRecipes() {
         return recipeService.getAllRecipes();
     }
 
-    @Operation(summary = "Get a recipe by id")
+    @Operation(summary = "Get a recipe by id", description = "Get recipe by id. Recipe id should be in the format of 'recipe_bmyxrshbfao9s1amjrvhoauob6mo'")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Recipe found"),
-        @ApiResponse(responseCode = "500", description = "Recipe not found")
+        @ApiResponse(responseCode = "200", description = "Recipe found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecipeDTO.class))),
+        @ApiResponse(responseCode = "500", description = "Recipe not found",
+            content = @Content),
     })
     @GetMapping("/{recipeId}")
     public RecipeEntity getRecipeById(@PathVariable String recipeId) {
@@ -44,10 +51,12 @@ public class RecipeController {
         return recipe;
     }
 
-    @Operation(summary = "Get all recipes by name partial")
+    @Operation(summary = "Get all recipes by name partial", description = "Get all recipes by name partial(i.e. 'chicken' will return all recipes with 'chicken' in the name)")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Recipes found"),
-        @ApiResponse(responseCode = "500", description = "Recipe not found")
+        @ApiResponse(responseCode = "200", description = "Recipes found",
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RecipeDTO.class)))),
+        @ApiResponse(responseCode = "500", description = "No recipes found with that name",
+            content = @Content),
     })
     @GetMapping("/search/{name}")
     public ResponseEntity<List<RecipeEntity>> getRecipeByName(@PathVariable String name) {
@@ -60,10 +69,12 @@ public class RecipeController {
         return ResponseEntity.status(HttpStatus.OK).body(recipes);
     }
 
-    @Operation(summary = "Get all recipe names")
+    @Operation(summary = "Get all recipe names", description = "Get all recipe names, returned in an array")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Recipe names returned"),
-        @ApiResponse(responseCode = "500", description = "Could not get recipe names")
+        @ApiResponse(responseCode = "200", description = "Recipe names returned",
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = String.class)))),
+        @ApiResponse(responseCode = "500", description = "Could not get recipe names",
+            content = @Content()),
     })
     @GetMapping("/names")
     public ResponseEntity<List<String>> getRecipeNames() {

--- a/Backend_Application/src/main/java/dsd/cohort/application/user/UserController.java
+++ b/Backend_Application/src/main/java/dsd/cohort/application/user/UserController.java
@@ -8,9 +8,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import dsd.cohort.application.ingredient.IngredientDTO;
 import dsd.cohort.application.ingredient.IngredientEntity;
+import dsd.cohort.application.recipe.RecipeDTO;
 import dsd.cohort.application.recipe.RecipeEntity;
+
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -31,10 +37,12 @@ public class UserController {
         return userService.getAll();
     }
 
-    @Operation(summary = "Create a new user")
+    @Operation(summary = "Create a new user", description = "Create a new user with the provided form data")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "All users returned"),
-        @ApiResponse(responseCode = "500", description = "Could not create user")
+        @ApiResponse(responseCode = "200", description = "User created",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserEntity.class))),
+        @ApiResponse(responseCode = "500", description = "Could not create user",
+            content = @Content(mediaType = "application/json")),
     })
     @PostMapping("/createuser")
     public ResponseEntity<UserEntity> createUser(@RequestBody UserRegisterDTO user) {
@@ -53,12 +61,13 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Add a recipe to a users favorites")
+    @Operation(summary = "Add a recipe to a user's favorites")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Recipe added to favorites"),
-        @ApiResponse(responseCode = "500", description = "Recipe not added to favorites")
+        @ApiResponse(responseCode = "200", description = "Recipe added to favorites",
+            content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Recipe not added to favorites",
+            content = @Content(mediaType = "application/json")),
     })
-    // add a recipe to a users favorites
     @PostMapping("/addrecipetofavorites")
     public ResponseEntity<String> addRecipe(@RequestBody UserDataRequestDTO userDataRequestDTO) {
         try {
@@ -73,12 +82,13 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Delete a recipe from a users favorites")
+    @Operation(summary = "Delete a recipe from a user's favorites")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Recipe deleted from favorites"),
-        @ApiResponse(responseCode = "500", description = "Recipe not deleted from favorites")
+        @ApiResponse(responseCode = "200", description = "Recipe deleted from favorites",
+            content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Recipe not deleted from favorites",
+            content = @Content(mediaType = "application/json")),
     })
-    // delete a recipe from a users favorites
     @DeleteMapping("/removerecipefromfavorites")
     public ResponseEntity<String> deleteRecipe(@RequestBody UserDataRequestDTO userDataRequestDTO) {
         try {
@@ -93,12 +103,13 @@ public class UserController {
 
     }
 
-    @Operation(summary = "Get a users favorites")
+    @Operation(summary = "Get a user's favorites")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Users favorites returned"),
-        @ApiResponse(responseCode = "500", description = "Could not get users favorites")
+        @ApiResponse(responseCode = "200", description = "User's favorites returned", 
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RecipeDTO.class)))),
+        @ApiResponse(responseCode = "500", description = "Could not get user's favorites",
+            content = @Content(mediaType = "application/json")),
     })
-    // get a users favorites
     @GetMapping("/getuserfavorites/{email}")
     public ResponseEntity<Set<RecipeEntity>> getUserFavorites(@PathVariable String email) {
         try {
@@ -111,10 +122,12 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Add an ingredient to a users grocery list")
+    @Operation(summary = "Add an ingredient to a user's grocery list")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Ingredient added to user's grocery list"),
-        @ApiResponse(responseCode = "500", description = "Could not add ingredient to user's grocery list.")
+        @ApiResponse(responseCode = "200", description = "Ingredient added to user's grocery list", 
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = IngredientDTO.class))),
+        @ApiResponse(responseCode = "500", description = "Could not add ingredient to user's grocery list.",
+            content = @Content(mediaType = "application/json")),
     })
     @PostMapping("/additemtogrocerylist")
     public ResponseEntity<String> addItemToGroceryList(@RequestBody UserDataRequestDTO userDataRequestDTO) {
@@ -131,10 +144,12 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Get a users grocery list")
+    @Operation(summary = "Get a user's grocery list")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Users grocery list returned"),
-        @ApiResponse(responseCode = "500", description = "Could not get user's grocery list")
+        @ApiResponse(responseCode = "200", description = "Users grocery list returned", 
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = IngredientDTO.class)))),
+        @ApiResponse(responseCode = "500", description = "Could not get user's grocery list",
+            content = @Content(mediaType = "application/json")),
     })
     @GetMapping("/getgrocerylist/{email}")
     public ResponseEntity<Set<IngredientEntity>> getGroceryList(@PathVariable String email) {
@@ -147,10 +162,12 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Remove an ingredient to a users grocery list")
+    @Operation(summary = "Remove an ingredient to a user's grocery list")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Ingredient removed from grocery list"),
-        @ApiResponse(responseCode = "500", description = "Ingredient not removed from grocery list")
+        @ApiResponse(responseCode = "200", description = "Ingredient removed from grocery list",
+            content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Ingredient not removed from grocery list",
+            content = @Content(mediaType = "application/json")),
     })
     @DeleteMapping("/removefromgrocerylist")
     public ResponseEntity<String> removeFromGroceryList(UserDataRequestDTO userDataRequestDTO) {
@@ -164,10 +181,12 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "User authentication")
+    @Operation(summary = "User authentication", description = "This endpoint authenticates a user, returns the user if authenticated or null if not")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "User authenticated"),
-        @ApiResponse(responseCode = "500", description = "User not authenticated")
+        @ApiResponse(responseCode = "200", description = "User authenticated",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserEntity.class))),
+        @ApiResponse(responseCode = "500", description = "User not authenticated",
+            content = @Content(mediaType = "application/json")),
     })
     @PostMapping("/auth")
     public ResponseEntity<UserEntity> userauth(@RequestBody UserRequestDTO userRequestDTO) {


### PR DESCRIPTION
This should finalize the swagger-ui documentation.

### Changes

- Added context to responses to make visible what a user should expect returned.
- Added additional description to various endpoints

### While the backend api is running, these dons are reachable by the link [swagger-ui](http://localhost:8080/api/v0/swagger-ui/index.html)

### Screenshot

![image](https://github.com/bethanyann/dsd-cohort-2024/assets/65290988/1310eca2-ed17-4754-8c55-1e91b4e35e1b)